### PR TITLE
Add super-linter and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -1,0 +1,23 @@
+name: Super-Linter
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Lint Code Base
+        uses: super-linter/super-linter@v6
+        env:
+          DEFAULT_BRANCH: main
+          VALIDATE_ALL_CODEBASE: false
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ Follow the prompts to generate barcodes.
 
 Contributions are welcome! Please fork the repository and submit a pull request.
 
+## Continuous Integration
+
+This project uses [GitHub Super-Linter](https://github.com/super-linter/super-linter)
+to validate code style in pull requests. Dependency updates are managed by
+Dependabot.
+
 ## License
 
 This project is licensed under the MIT License.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "random-barcode",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "random-barcode",
-      "version": "0.0.0",
+      "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "jsbarcode": "^3.11.6",
         "react": "^19.0.0",


### PR DESCRIPTION
## Summary
- add GitHub Super-Linter workflow
- configure Dependabot for npm and GitHub Actions
- document CI tooling in README
- fetch full git history in Super-Linter workflow

## Testing
- `npm run lint`
