### PR TITLE
ci: integrate release automation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,10 +2,10 @@
 name: Deploy static content to Pages
 
 on:
-  # Runs on pushes targeting the default branch
-  push:
-    branches: ['main']
-
+  # Runs after a GitHub release is published
+  release:
+    types: [published]
+  
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,20 @@
+name: release-please
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v4
+        with:
+          release-type: node
+          package-name: random-barcode

--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ Follow the prompts to generate barcodes.
 
 Contributions are welcome! Please fork the repository and submit a pull request.
 
+## Deployment
+
+Releases are managed by [release-please](https://github.com/googleapis/release-please).
+Publishing a release automatically triggers a deployment to GitHub Pages.
+
 ## License
 
 This project is licensed under the MIT License.


### PR DESCRIPTION
## Summary
- automate versioning with release-please
- deploy GitHub Pages after a release is published
- document deployment process in README

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6840f69a4e688325882fa9807fe9bd02