### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- add a default dependabot configuration

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6840f8c851908325b38830c8ac6baf20