### PR TITLE
Display app version in footer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -103,7 +103,7 @@ function App() {
         <button onClick={clearBarcodesParam}>Remove Barcodes Query Param</button>
       )}
       <p className="footer">
-        Made with ❤️ by{" "}
+        v{APP_VERSION} – Made with ❤️ by{" "}
         <a
           className="footer-link"
           href="https://github.com/schie"

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="vite/client" />
+
+declare const APP_VERSION: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,12 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
+import pkg from "./package.json" assert { type: "json" };
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
   base: "/random-barcode/",
+  define: {
+    APP_VERSION: JSON.stringify(pkg.version),
+  },
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,12 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
-import pkg from "./package.json" assert { type: "json" };
+import { version } from "./package.json" assert { type: "json" };
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
   base: "/random-barcode/",
   define: {
-    APP_VERSION: JSON.stringify(pkg.version),
+    APP_VERSION: JSON.stringify(version),
   },
 });


### PR DESCRIPTION
## Summary
- export package version as `APP_VERSION`
- show the version with a `v` prefix next to the footer credit

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68424cc4c1188325be3044af7e319471