### PR TITLE
Add manual deploy workflow

### DIFF
--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -1,0 +1,34 @@
+name: manual-deploy
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/configure-pages@v4
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: './dist'
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Contributions are welcome! Please fork the repository and submit a pull request.
 
 Releases are managed by [release-please](https://github.com/googleapis/release-please).
 Publishing a release automatically triggers a deployment to GitHub Pages.
+If the automatic deployment fails, you can trigger the **Manual Deploy** workflow
+from the GitHub Actions tab to redeploy the site.
 
 ## License
 


### PR DESCRIPTION
## Summary
- add `manual-deploy` workflow for GitHub Pages
- document how to trigger the manual deploy

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6842602f47c4832580cb78ef272f33c6