### PR TITLE
Add info modal for usage docs

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -61,3 +61,37 @@
     padding: 1em;
   }
 }
+
+.info-button {
+  margin: 1rem 0;
+}
+
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(2px);
+}
+
+.modal {
+  background-color: #fff;
+  color: #000;
+  padding: 2rem;
+  border-radius: 8px;
+  max-width: 600px;
+  width: 90%;
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.25);
+}
+
+@media (prefers-color-scheme: dark) {
+  .modal {
+    background-color: #1a1a1a;
+    color: #fff;
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,6 +38,7 @@ const clearBarcodesParam = () => {
  */
 function App() {
   const [enabled, setEnabled] = useState(true);
+  const [showInfo, setShowInfo] = useState(false);
 
   const containerRef = useRef<SVGSVGElement>(null);
 
@@ -80,9 +81,12 @@ function App() {
   }, []);
 
   const docsAddendum = useMemo(
-    () => `Click it to ${enabled ? "pause" : "continue"}`,
-    [enabled]
+    () => `Click it to ${enabled ? 'pause' : 'continue'}`,
+    [enabled],
   );
+
+  const openInfo = useCallback(() => setShowInfo(true), []);
+  const closeInfo = useCallback(() => setShowInfo(false), []);
 
   return (
     <>
@@ -90,15 +94,23 @@ function App() {
         <svg className="barcode" ref={containerRef} onClick={toggle} />
       </div>
       <p className="read-the-docs">Just a random barcode.</p>
-      <p className="read-the-docs">{docsAddendum}</p>
+      <button className="info-button" onClick={openInfo}>Info</button>
+      {showInfo && (
+        <div className="modal-overlay" onClick={closeInfo}>
+          <div className="modal" onClick={(e) => e.stopPropagation()}>
+            <p className="read-the-docs">{docsAddendum}</p>
+            <p className="read-the-docs">
+              Use the <code>barcodes</code> query parameter to provide a custom list of barcodes.
+              <br />
+              For example: <code>?barcodes=12345,67890,ABCDE</code>.
+              <br />
+              The app will randomly select barcodes from this list.
+            </p>
+            <button onClick={closeInfo}>Close</button>
+          </div>
+        </div>
+      )}
       <hr />
-      <p className="read-the-docs">
-        Use the <code>barcodes</code> query parameter to provide a custom list of barcodes.
-        <br />
-        For example: <code>?barcodes=12345,67890,ABCDE</code>.
-        <br />
-        The app will randomly select barcodes from this list.
-      </p>
       {barcodes.length > 0 && (
         <button onClick={clearBarcodesParam}>Remove Barcodes Query Param</button>
       )}


### PR DESCRIPTION
## Summary
- introduce `showInfo` state for modal visibility
- render Info button and modal explaining how to pause and use query params
- style modal overlay and info button

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68426c07aeb4832590b4f36a0652e480